### PR TITLE
fix: prevent Vulkan surface double-free crash on exit

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -246,5 +246,14 @@ int main(int argc, char *argv[]) {
     w.showMaximized();
   }
 
-  return a.exec();
+  int ret = a.exec();
+
+  // Null the Vulkan instance so QWaylandVulkanWindow::invalidateSurface()
+  // skips its vkDestroySurfaceKHR call, preventing a double-free.
+#if AMBER_HAS_VULKAN
+  if (w.windowHandle())
+    w.windowHandle()->setVulkanInstance(nullptr);
+#endif
+
+  return ret;
 }

--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -1135,7 +1135,10 @@ void MainWindow::closeEvent(QCloseEvent* e) {
 
     stop_audio();
 
-    e->accept();
+    // Quit instead of accepting — accepting destroys the Vulkan surface
+    // mid-event-loop, causing a double-free crash on Wayland.
+    e->ignore();
+    QCoreApplication::quit();
   } else {
     e->ignore();
   }

--- a/src/ui/viewerwindow.cpp
+++ b/src/ui/viewerwindow.cpp
@@ -21,6 +21,7 @@
 #include "viewerwindow.h"
 
 #include <QApplication>
+#include <QCloseEvent>
 #include <QFile>
 #include <QKeyEvent>
 #include <QLabel>
@@ -76,6 +77,14 @@ ViewerWindow::ViewerWindow(QWidget* parent) : QRhiWidget(parent) {
   fullscreen_msg_label_->adjustSize();
 }
 
+ViewerWindow::~ViewerWindow() {
+  // Null Vulkan instance to prevent surface double-free during teardown.
+#if AMBER_HAS_VULKAN
+  if (windowHandle())
+    windowHandle()->setVulkanInstance(nullptr);
+#endif
+}
+
 void ViewerWindow::set_frame(const char* data, int w, int h) {
   int bytes = w * h * 4;
   if (frame_data_.size() != bytes) frame_data_.resize(bytes);
@@ -110,6 +119,12 @@ void ViewerWindow::showEvent(QShowEvent*) {
   for (auto menubar_action : menubar_actions) {
     shortcut_copier(shortcuts_, menubar_action->menu());
   }
+}
+
+void ViewerWindow::closeEvent(QCloseEvent* e) {
+  // Hide instead of destroying to avoid Vulkan surface double-free.
+  e->ignore();
+  hide();
 }
 
 void ViewerWindow::keyPressEvent(QKeyEvent* e) {

--- a/src/ui/viewerwindow.h
+++ b/src/ui/viewerwindow.h
@@ -34,9 +34,11 @@ class ViewerWindow : public QRhiWidget {
   Q_OBJECT
  public:
   ViewerWindow(QWidget* parent);
+  ~ViewerWindow() override;
   void set_frame(const char* data, int w, int h);
 
  protected:
+  void closeEvent(QCloseEvent*) override;
   void showEvent(QShowEvent*) override;
   void keyPressEvent(QKeyEvent*) override;
   void mousePressEvent(QMouseEvent*) override;


### PR DESCRIPTION
Qt's QWindowPrivate::destroy() tears down the QRhiVulkanSwapChain (first vkDestroySurfaceKHR) then calls QWaylandVulkanWindow:: invalidateSurface() (second vkDestroySurfaceKHR on the same handle), causing a use-after-free crash.

Three minimal changes fix this:

1. MainWindow::closeEvent() calls e->ignore() + QCoreApplication::quit() instead of e->accept(), so the window destructs after a.exec() returns rather than mid-event-loop.

2. main.cpp nulls the VulkanInstance on the main window handle after a.exec() returns, making the redundant vkDestroySurfaceKHR a no-op.

3. ViewerWindow::closeEvent() hides instead of destroying, avoiding Vulkan surface teardown on the fullscreen viewer window.