### PR TITLE
Fix Arch PKGBUILD and point to v1.7.5

### DIFF
--- a/packaging/linux/PKGBUILD
+++ b/packaging/linux/PKGBUILD
@@ -1,5 +1,5 @@
 pkgname=amber-editor
-pkgver=1.4.0
+pkgver=1.7.5
 pkgrel=1
 pkgdesc='Professional open-source non-linear video editor'
 arch=('x86_64')
@@ -17,7 +17,7 @@ makedepends=(
   'qt6-tools'
 )
 conflicts=('olive')
-source=("git+ssh://git@github.com/baptisterajaut/amber.git#branch=0.1.x")
+source=("git+https://github.com/baptisterajaut/amber.git#tag=v1.7.5")
 sha256sums=('SKIP')
 
 build() {


### PR DESCRIPTION
Wasn't compiling before because the wrong protocol was used to clone the git repo. Also, it was pointing to a very old version, so i pointed to 1.7.5, which is the latest version tag while i made that commit.

Making the PKGBUILD manually compile the last version as of it's edit time seems not the best practice, but i don't know how or if are you managing the updates, so i'm just making it work.

Also, thanks for keeping alive the good idea that was Matt's video editor :)